### PR TITLE
Add fee estimation interface

### DIFF
--- a/src/Lyn.Protocol/Common/Blockchain/IFeeEstimation.cs
+++ b/src/Lyn.Protocol/Common/Blockchain/IFeeEstimation.cs
@@ -1,0 +1,12 @@
+﻿using Lyn.Types.Bitcoin;
+using Lyn.Types.Fundamental;
+
+namespace Lyn.Protocol.Common.Blockchain
+{
+    public interface IFeeEstimation
+    {
+        Satoshis GetFeeRate(UInt256 chainid);
+
+        Satoshis GetFee(UInt256 chainid, int virtualSize);
+    }
+}


### PR DESCRIPTION
Started on this and realized I have some open questions.
- fee rate has several valid values (confirm in 1 hour or 4 hours or even days) how is the unit we use number of blocks or number of hours?
- do we add a special enum that is more friendly to the user (very-fast/fast/slow)